### PR TITLE
resolvendo conflitos de saída.

### DIFF
--- a/src/cliente/Escritor.java
+++ b/src/cliente/Escritor.java
@@ -10,7 +10,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public class Escritor implements Runnable {
     private final Socket socket;
     private final BufferedWriter bufferedWriter;
-    private final Scanner scanner;
     private AtomicBoolean active;
     private final BlockingQueue<String> messageQueue;
 
@@ -19,7 +18,6 @@ public class Escritor implements Runnable {
         this.bufferedWriter = bufferedWriter;
         this.active = active;
         this.messageQueue = messageQueue;
-        this.scanner = new Scanner(System.in);
     }
 
     @Override
@@ -38,7 +36,8 @@ public class Escritor implements Runnable {
                 this.bufferedWriter.newLine();
                 this.bufferedWriter.flush();
                 if (mensagem.equals("999")) {
-                    System.out.println("Pressione qualquer tecla...");
+                    Thread.sleep(500);
+                    System.out.println("Pressione qualquer tecla para continuar...");
                     active.set(false);
                 }
             }

--- a/src/servidor/Sessao.java
+++ b/src/servidor/Sessao.java
@@ -152,28 +152,28 @@ public class Sessao {
         sessoes.get(user.getSessao()).partida.combate(user, jogada);
     }
 
-    protected static void sairPartida(Usuario user){
+    protected synchronized static void sairPartida(Usuario user){
         Sessao sessao = sessoes.get(user.getSessao());
         sessao.partida = null;
         user.setPartida(false);
-        user.write("305 Você saiu da partida.");
-        sairSessao(user);
+        user.write("\"305 Você saiu da partida.");
 
-        if(sessao.user1 == user){
+        if(sessao.user1 == user && sessao.user2 != null){
             sessao.user2.setPartida(false);
             sessao.user2.write("305 Seu oponente saiu da partida.");
             sairSessao(sessao.user2);
         }
-        else if(sessao.user2 == user){
+        else if(sessao.user2 == user && sessao.user1 != null){
             sessao.user1.setPartida(false);
             sessao.user1.write("305 Seu oponente saiu da partida.");
             sairSessao(sessao.user1);
         }
+        sairSessao(user);
     }
 
     protected static void escrever(Usuario userAtual, String mensagem){
         Sessao sessao = sessoes.get(userAtual.getSessao());
-
+        if (sessao == null) return;
         Usuario userOutro = sessao.user2;
         if(sessao.user2 == userAtual) userOutro = sessao.user1;
 

--- a/src/servidor/Usuario.java
+++ b/src/servidor/Usuario.java
@@ -15,6 +15,7 @@ public class Usuario implements Runnable {
     private BufferedWriter bufferedWriter;
     private String username = "";
     private Boolean flagPartida;
+    private Boolean active = true;
 
     public Usuario(Socket socket){
         try{
@@ -33,6 +34,7 @@ public class Usuario implements Runnable {
     }
 
     public void write(String mensagem){
+        if (!active) return;
         try{
             this.bufferedWriter.write(mensagem);
             this.bufferedWriter.newLine();
@@ -40,6 +42,7 @@ public class Usuario implements Runnable {
         }
         catch(IOException e){
             System.out.println("Não foi possível escrever a mensagem: " + e.getMessage());
+            e.printStackTrace();
         }
     }
 
@@ -83,6 +86,9 @@ public class Usuario implements Runnable {
 
     public void closeEverything(){
         try {
+            active = false;
+            System.out.println("ID SESSÃO: " + this.idSessao);
+            if (this.idSessao != -1) Sessao.sairPartida(this);
             if (this.bufferedReader != null) this.bufferedReader.close();
             if (this.bufferedWriter != null) this.bufferedWriter.close();
             if (this.socket != null) this.socket.close();
@@ -118,6 +124,8 @@ public class Usuario implements Runnable {
                 case "115":
                     Sessao.sairPartida(this);
                     break;
+                case "999":
+                    this.closeEverything();
                 case "1102":
                     Sessao.escrever(this, conteudo);
                     break;


### PR DESCRIPTION
Para resolver, foram feitos os seguintes testes:

Testes para saída fechamento de cliente:
	- fechamento inesperado: 
		fechar o terminal durante a partida ✅
		fechar o terminal durante a sessão ✅
		fechar o terminal durante a aplicação ✅
	- fechamento esperado:
		/fechar durante a aplicação ✅
		/fehcar durante a sessao ✅
		/fehcar durante a partida ✅
		/sair_partida durante a partida ✅

Testes para saída fechamento de servidor:
	- fechamento inesperado:
		fechar o terminal -> Quando o servidor fecha nesse caso, não avisa nada para o usuário, ele simplesmente para a execução no próximo comando. Para resolver isso, podemos implementar um keepAlive. 🐕